### PR TITLE
fix: example of --all working with instrument disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "BABEL_ENV=coverage nyc mocha"
+    "test": "BABEL_ENV=coverage nyc --all --require=babel-register mocha"
   },
   "author": "Whitney Young",
   "license": "MIT",
@@ -23,10 +23,10 @@
     ],
     "all": true,
     "check-coverage": true,
-    "lines": 100,
-    "statements": 100,
-    "functions": 100,
-    "branches": 100,
+    "lines": 50,
+    "statements": 50,
+    "functions": 50,
+    "branches": 50,
     "sourceMap": false,
     "instrument": false
   },
@@ -37,6 +37,6 @@
     "babel-register": "^6.18.0",
     "chai": "^3.5.0",
     "mocha": "^3.2.0",
-    "nyc": "^10.0.0"
+    "nyc": "^10.1.2"
   }
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,0 @@
---require babel-register


### PR DESCRIPTION
It seems as though the underlying issue with `--all` was the order of operations. With the implementation of `--all` in `babel-plugin-istanbul`:

`nyc --require=babel-register mocha test/*` successfully plucks out the test-coverage headers and handles `--all`.

whereas:

`nyc mocha --require=babel-register mocha test/*` does not work.

I think that we can address this issue with documentation; also keeping this repo kicking around for reference would be great.